### PR TITLE
Fixes the timing of the button injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Auto Prefixer
 
-With thanks from Tim Butterworth, Alex Kramer, Mark McDonald
+With thanks to Tim Butterworth, [Alex Kramer](https://github.com/mitochondrion), [Mark McDonald](https://github.com/MarkyMarkMcDonald)

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,46 +1,69 @@
 chrome.extension.sendMessage({}, function (response) {
-    var readyStateCheckInterval = setInterval(function () {
-        if (document.readyState === "complete") {
-            clearInterval(readyStateCheckInterval);
+  var readyStateCheckInterval = setInterval(function () {
+    if (document.readyState === "complete") {
+      clearInterval(readyStateCheckInterval);
+    } else {
+      return;
+    }
 
-            // ----------------------------------------------------------
-            // This part of the script triggers when page is done loading
-            console.log("Hello. This message was sent from scripts/inject.js");
-            // ----------------------------------------------------------
-            $.fn.scramble = function () {
-                var length = this.length;
-                if (length > 0) {
-                    var randomIndex;
-                    var tmp;
-                    while (--length) {
-                        randomIndex = Math.floor(Math.random() * (length + 1));
-                        this.eq(randomIndex).insertBefore(this[length]);
+    // ----------------------------------------------------------
+    // This part of the script triggers when page is done loading
+    console.log("==========> Hello. This message was sent from scripts/inject.js");
+    // ----------------------------------------------------------
 
-                    }
-                }
-                return this;
-            };
+    $.fn.scramble = function () {
+      var length = this.length;
+      if (length > 0) {
+        var randomIndex;
+        var tmp;
+        while (--length) {
+          randomIndex = Math.floor(Math.random() * (length + 1));
+          this.eq(randomIndex).insertBefore(this[length]);
 
-            var thing = '<li class="item dice_roller" title="I’m feeling lucky">' +
-                '<label for="sidebar_panel_project_history_1166228" class="project_history" id="sidebar_panel_label_project_history_1166228_">' +
-                            '<span class="panel_name">Auto Prioritizer</span>' +
-                                '</label>' +
-                        '</li>';
-
-            var rollTheDice = function(event) {
-                event.preventDefault();
-                console.log("error: success!!");
-                var stories = $('.backlog .story');
-
-                $('<audio autoplay="true" src="http://mikekenyon.ca/thing_noise.mp3"></audio>').prependTo($('body'));
-
-                for (var i = 0; i < 50; ++i) {
-                    setTimeout(stories.scramble.bind(stories), i * 100);
-                }
-            };
-
-            $(thing).insertAfter($('.item.project_history'));
-            $('body').on('click', '.item.dice_roller', rollTheDice);
         }
-    }, 10);
+      }
+      return this;
+    };
+
+    var rollTheDice = function(event) {
+      event.preventDefault();
+      console.log("error: success!!");
+      var stories = $('.backlog .story');
+
+      $('<audio autoplay="true" src="http://mikekenyon.ca/thing_noise.mp3"></audio>').prependTo($('body'));
+
+      for (var i = 0; i < 50; ++i) {
+        setTimeout(stories.scramble.bind(stories), i * 100);
+      }
+    };
+
+    var insertDiceButton = function() {
+      console.log('=============> insertDiceButton()');
+
+      var diceButtonHtml =
+        '<li class="item dice_roller" title="I’m feeling lucky">' +
+        '  <label for="sidebar_panel_project_history_1166228" class="project_history" id="sidebar_panel_label_project_history_1166228_">' +
+        '    <span class="panel_name">Auto Prioritizer</span>' +
+        '  </label>' +
+        '</li>';
+
+      $('.item.dice_roller').remove();
+      $(diceButtonHtml).insertAfter($('.item.project_history'));
+      $('body').on('click', '.item.dice_roller', rollTheDice);
+    };
+
+    insertDiceButton();
+
+    setTimeout(function() { // wait for Tracker to start loading stories
+      var checkLoadingInterval = setInterval(function() { // poll for Tracker to have finished loading stories
+        if ($('h2:contains(loading project)').size() == 0) {
+          clearInterval(checkLoadingInterval);
+
+          setTimeout(function() { // wait for Tracker to have finished messing with the DOM after stories have been loaded
+            insertDiceButton();
+          }, 100);
+        }
+      }, 10);
+    }, 100);
+  }, 10);
 });


### PR DESCRIPTION
This change polls the page until Tracker has finished loading stories and then re-injects the dice button.  For any project with more than a few stories, the dice button tends to get added to the DOM before Tracker finishes loading stories, and at some point during loading, Tracker futzes with the DOM and removes the button.  Now it works for any size project.
